### PR TITLE
Attempted Fix for appveyor yaml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ environment:
 
 # Build
 
-build: off
+build:
 
 install:
   # Install the specific Go version.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ environment:
 
 # Build
 
-build: false
+build: off
 
 install:
   # Install the specific Go version.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ environment:
 
 # Build
 
-build: Script
+build: off
 
 install:
   # Install the specific Go version.
@@ -26,7 +26,7 @@ install:
   - go version
   - go env
 
-build_script:
+test_script:
   - cd c:\gopath\src\github.com\amitsaha\gitbackup
   - go build -o bin\gitbackup.exe 
   - go test -v

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,10 +24,7 @@ install:
   - go version
   - go env
 
-build: off
-
-
-test_script:
+build_script:
   - cd c:\gopath\src\github.com\amitsaha\gitbackup
   - go build -o bin\gitbackup.exe 
   - go test -v

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ environment:
 
 # Build
 
-build: off
+build: Script
 
 install:
   # Install the specific Go version.
@@ -26,7 +26,7 @@ install:
   - go version
   - go env
 
-test_script:
+build_script:
   - cd c:\gopath\src\github.com\amitsaha\gitbackup
   - go build -o bin\gitbackup.exe 
   - go test -v

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,8 @@ environment:
 
 # Build
 
+build: off
+
 install:
   # Install the specific Go version.
   - rmdir c:\go /s /q
@@ -27,4 +29,7 @@ install:
 build_script:
   - cd c:\gopath\src\github.com\amitsaha\gitbackup
   - go build -o bin\gitbackup.exe 
+
+test_script:
+  - cd c:\gopath\src\github.com\amitsaha\gitbackup
   - go test -v

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ environment:
 
 # Build
 
-build:
+build: false
 
 install:
   # Install the specific Go version.
@@ -26,10 +26,7 @@ install:
   - go version
   - go env
 
-build_script:
-  - cd c:\gopath\src\github.com\amitsaha\gitbackup
-  - go build -o bin\gitbackup.exe 
-
 test_script:
   - cd c:\gopath\src\github.com\amitsaha\gitbackup
+  - go build -o bin\gitbackup.exe 
   - go test -v


### PR DESCRIPTION
Appveyor is currently failing with:

```
The build phase is set to "MSBuild" mode (default), but no Visual Studio project or solution files were found in the root directory. If you are not building Visual Studio project switch build mode to "Script" and provide your custom build command
```