### PR TITLE
Gitlab project membership + visibility updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,9 @@ _testmain.go
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+gitbackup
 # external packages folder
 #vendor/
 #
-.DS_Store
+
+#

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,7 @@ install: true
 script:
   - go get -u golang.org/x/lint/golint
   - cd $GOPATH/src/github.com/amitsaha/gitbackup/
-  - env GO111MODULE=on go build
-  - env GO111MODULE=on $(go env GOBIN)/golint
-  - env GO111MODULE=on go test -v
+  - bash ./check_test.bash
   - bash ./build-binaries.bash
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,16 @@ language: go
 os:
   - linux
   - osx
-go: 
+go:
   - 1.12.x
 
 install: true
 
 script:
+  - go get -u golang.org/x/lint/golint
   - cd $GOPATH/src/github.com/amitsaha/gitbackup/
   - env GO111MODULE=on go build
-  - env GO111MODULE=on golint
+  - env GO111MODULE=on $(go env GOBIN)/golint
   - env GO111MODULE=on go test -v
   - bash ./build-binaries.bash
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ install: true
 script:
   - cd $GOPATH/src/github.com/amitsaha/gitbackup/
   - env GO111MODULE=on go build
+  - env GO111MODULE=on golint
   - env GO111MODULE=on go test -v
   - bash ./build-binaries.bash
 

--- a/README.md
+++ b/README.md
@@ -2,22 +2,22 @@
 
 Linux/Mac OS X [![Build Status](https://travis-ci.org/amitsaha/gitbackup.svg?branch=master)](https://travis-ci.org/amitsaha/gitbackup) Windows [![Build status](https://ci.appveyor.com/api/projects/status/fwki40x1havyian2/branch/master?svg=true)](https://ci.appveyor.com/project/amitsaha/gitbackup/branch/master)
 
-``gitbackup`` is a tool to backup your git repositories from GitHub (including GitHub enterprise) or 
-GitLab (including custom GitLab installations). 
+``gitbackup`` is a tool to backup your git repositories from GitHub (including GitHub enterprise) or
+GitLab (including custom GitLab installations).
 
-``gitbackup`` only creates a backup of the repository and does not currently support issues, 
+``gitbackup`` only creates a backup of the repository and does not currently support issues,
 pull requests or other data associated with a git repository. This may or may not be in the future
 scope of this tool.
 
-If you are following along my Linux Journal article, please obtain the version of the source tagged 
+If you are following along my Linux Journal article, please obtain the version of the source tagged
 with [lj-0.1](https://github.com/amitsaha/gitbackup/releases/tag/lj-0.1).
 
 ## Using ``gitbackup``
 
 Binary releases are available from the [Releases](https://github.com/amitsaha/gitbackup/releases/) page. Please download the ZIP corresponding to your OS and architecture and unzip the binary somewhere in your ``$PATH``.
 
-``gitbackup`` requires a [GitHub API access token](https://github.com/blog/1509-personal-api-tokens) for 
-backing up GitHub repositories and [GitLab personal access token](https://gitlab.com/profile/personal_access_tokens) 
+``gitbackup`` requires a [GitHub API access token](https://github.com/blog/1509-personal-api-tokens) for
+backing up GitHub repositories and [GitLab personal access token](https://gitlab.com/profile/personal_access_tokens)
 for GitLab. You can supply the token to ``gitbackup`` using ``GITHUB_TOKEN`` and ``GITLAB_TOKEN`` environment variables respectively.
 
 Typing ``-help`` will display the command line options that ``gitbackup`` recognizes:
@@ -26,15 +26,17 @@ Typing ``-help`` will display the command line options that ``gitbackup`` recogn
 $ gitbackup -help
 Usage of ./bin/gitbackup:
   -backupdir string
-    	Backup directory
+        Backup directory
   -githost.url string
-    	DNS of the custom Git host
+        DNS of the custom Git host
   -github.repoType string
-    	Repo types to backup (all, owner, member) (default "all")
+        Repo types to backup (all, owner, member) (default "all")
+  -gitlab.projectMembershipType string
+        Project type to clone (owner, member, both) (default "both")
   -gitlab.projectVisibility string
-    	Visibility level of Projects to clone (default "internal")
+        Visibility level of Projects to clone (internal, public, private) (default "internal")
   -service string
-    	Git Hosted Service Name (github/gitlab)
+        Git Hosted Service Name (github/gitlab)
 ```
 ### Backing up your GitHub repositories
 
@@ -58,7 +60,7 @@ $ GITHUB_TOKEN=secret$token gitbackup -service github -github.repoType member
 
 ### Backing up your GitLab repositories
 
-To backup all projects which have their [visibility](https://docs.gitlab.com/ce/api/projects.html#project-visibility-level) set to 
+To backup all projects which have their [visibility](https://docs.gitlab.com/ce/api/projects.html#project-visibility-level) set to
 "internal" on ``https://gitlab.com`` to the default backup directory (``$HOME/.gitbackup/``):
 
 ```lang=bash
@@ -77,10 +79,28 @@ To backup only the private repositories:
 $ GITLAB_TOKEN=secret$token gitbackup -service gitlab -gitlab.projectVisibility private
 ```
 
+To backup private repositories which you are a member or owner of:
+
+```lang=bash
+$ GITLAB_TOKEN=secret$token gitbackup \
+    -service gitlab \
+    -gitlab.projectVisibility private \
+    -gitlab.projectMembershipType both
+```
+
+To backup public repositories which you are an owner of:
+
+```lang=bash
+$ GITLAB_TOKEN=secret$token gitbackup \
+    -service gitlab \
+    -gitlab.projectVisibility public \
+    -gitlab.projectMembershipType owner
+```
+
 
 ### GitHub Enterprise or custom GitLab installation
 
-To specify a custom GitHub enterprise or GitLab location, specify the ``service`` as well as the 
+To specify a custom GitHub enterprise or GitLab location, specify the ``service`` as well as the
 the ``githost.url`` flag, like so
 
 ```lang=bash
@@ -106,7 +126,7 @@ If you have specified a Git Host URL, it will create a directory structure ``dat
 
 If you have Golang 1.12.x+ installed, you can clone the repository and:
 ```
-$ go build 
+$ go build
 ```
 
 The built binary will be ``gitbackup``.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,9 +18,5 @@ install:
 build: off
 
 test_script:
-  - go get -u golang.org/x/lint/golint
-  - set Path=c:\go\bin;%Path%
   - go build -o bin\gitbackup.exe
-  - dir c:\go\bin
-  - golint.exe -set_exit_status
   - go test -v

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,5 +23,7 @@ build: off
 test_script:
   - set Path=c:\go\bin;c:\gopath\bin;%Path%
   - go build -o bin\gitbackup.exe
-  - golint.exe
+  - dir c:\go\bin
+  - dir c:\gopath\bin
+  - golint.exe -set_exit_status
   - go test -v

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,7 @@ install:
 build: off
 
 test_script:
+  - set Path=c:\go\bin;c:\gopath\bin;%Path%
   - go build -o bin\gitbackup.exe
-  - golint
+  - golint.exe
   - go test -v

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,4 +21,5 @@ build: off
 
 test_script:
   - go build -o bin\gitbackup.exe 
+  - golint
   - go test -v

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,10 +16,11 @@ install:
   - msiexec /i go%GOVERSION%.windows-amd64.msi /q
   - set Path=c:\go\bin;c:\gopath\bin;%Path%
   - go version
+  - go get -u golang.org/x/lint/golint
 
 build: off
 
 test_script:
-  - go build -o bin\gitbackup.exe 
+  - go build -o bin\gitbackup.exe
   - golint
   - go test -v

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,16 +14,13 @@ install:
   - rmdir c:\go /s /q
   - appveyor DownloadFile https://storage.googleapis.com/golang/go%GOVERSION%.windows-amd64.msi
   - msiexec /i go%GOVERSION%.windows-amd64.msi /q
-  - set Path=c:\go\bin;c:\gopath\bin;%Path%
-  - go version
-  - go get -u golang.org/x/lint/golint
 
 build: off
 
 test_script:
-  - set Path=c:\go\bin;c:\gopath\bin;%Path%
+  - go get -u golang.org/x/lint/golint
+  - set Path=c:\go\bin;%Path%
   - go build -o bin\gitbackup.exe
   - dir c:\go\bin
-  - dir c:\gopath\bin
   - golint.exe -set_exit_status
   - go test -v

--- a/backup.go
+++ b/backup.go
@@ -7,7 +7,7 @@ import (
 	"path"
 	"sync"
 
-	"github.com/mitchellh/go-homedir"
+	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/afero"
 )
 
@@ -38,7 +38,7 @@ func backUp(backupDir string, repo *Repository, wg *sync.WaitGroup) ([]byte, err
 	return stdoutStderr, err
 }
 
-func setupBackupDir(backupDir string, service string, githostUrl string) string {
+func setupBackupDir(backupDir string, service string, githostURL string) string {
 	if len(backupDir) == 0 {
 		homeDir, err := homedir.Dir()
 		if err == nil {
@@ -48,11 +48,11 @@ func setupBackupDir(backupDir string, service string, githostUrl string) string 
 			log.Fatal("Could not determine home directory and backup directory not specified")
 		}
 	} else {
-		if len(githostUrl) == 0 {
+		if len(githostURL) == 0 {
 			service = service + ".com"
 			backupDir = path.Join(backupDir, service)
 		} else {
-			u, err := url.Parse(githostUrl)
+			u, err := url.Parse(githostURL)
 			if err != nil {
 				panic(err)
 			}

--- a/check_test.bash
+++ b/check_test.bash
@@ -4,6 +4,6 @@ set -e
 
 export GO111MODULE=on
 go env
-golint
+golint -set_exit_status
 go build
 go test

--- a/check_test.bash
+++ b/check_test.bash
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 export GO111MODULE=on
 go env
 golint

--- a/check_test.bash
+++ b/check_test.bash
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+export GO111MODULE=on
+go env
+golint
+go build
+go test

--- a/client.go
+++ b/client.go
@@ -6,23 +6,23 @@ import (
 	"os"
 
 	"github.com/google/go-github/github"
-	"github.com/xanzy/go-gitlab"
+	gitlab "github.com/xanzy/go-gitlab"
 	"golang.org/x/oauth2"
 )
 
-func NewClient(service string, gitHostUrl string) interface{} {
-	var gitHostUrlParsed *url.URL
+func newClient(service string, gitHostURL string) interface{} {
+	var gitHostURLParsed *url.URL
 	var err error
 
 	// If a git host URL has been passed in, we assume it's
 	// a gitlab installation
-	if len(gitHostUrl) != 0 {
-		gitHostUrlParsed, err = url.Parse(gitHostUrl)
+	if len(gitHostURL) != 0 {
+		gitHostURLParsed, err = url.Parse(gitHostURL)
 		if err != nil {
-			log.Fatalf("Invalid gitlab URL: %s", gitHostUrl)
+			log.Fatalf("Invalid gitlab URL: %s", gitHostURL)
 		}
 		api, _ := url.Parse("api/v4/")
-		gitHostUrlParsed = gitHostUrlParsed.ResolveReference(api)
+		gitHostURLParsed = gitHostURLParsed.ResolveReference(api)
 	}
 
 	if service == "github" {
@@ -35,8 +35,8 @@ func NewClient(service string, gitHostUrl string) interface{} {
 		)
 		tc := oauth2.NewClient(oauth2.NoContext, ts)
 		client := github.NewClient(tc)
-		if gitHostUrlParsed != nil {
-			client.BaseURL = gitHostUrlParsed
+		if gitHostURLParsed != nil {
+			client.BaseURL = gitHostURLParsed
 		}
 		return client
 	}
@@ -47,8 +47,8 @@ func NewClient(service string, gitHostUrl string) interface{} {
 			log.Fatal("GITLAB_TOKEN environment variable not set")
 		}
 		client := gitlab.NewClient(nil, gitlabToken)
-		if gitHostUrlParsed != nil {
-			client.SetBaseURL(gitHostUrlParsed.String())
+		if gitHostURLParsed != nil {
+			client.SetBaseURL(gitHostURLParsed.String())
 		}
 		return client
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-github/github"
-	"github.com/xanzy/go-gitlab"
+	gitlab "github.com/xanzy/go-gitlab"
 )
 
 func TestNewClient(t *testing.T) {
@@ -18,29 +18,29 @@ func TestNewClient(t *testing.T) {
 	expectedGitHostBaseURL := customGitHost.ResolveReference(api)
 
 	// Client for github.com
-	client := NewClient("github", "")
+	client := newClient("github", "")
 	client = client.(*github.Client)
 
 	// Client for Enterprise Github
-	client = NewClient("github", customGitHost.String())
+	client = newClient("github", customGitHost.String())
 	gotBaseURL := client.(*github.Client).BaseURL
 	if gotBaseURL.String() != expectedGitHostBaseURL.String() {
 		t.Errorf("Expected BaseURL to be: %v, Got: %v\n", expectedGitHostBaseURL, gotBaseURL)
 	}
 
 	// Client for gitlab.com
-	client = NewClient("gitlab", "")
+	client = newClient("gitlab", "")
 	client = client.(*gitlab.Client)
 
 	// Client for custom gitlab installation
-	client = NewClient("gitlab", customGitHost.String())
+	client = newClient("gitlab", customGitHost.String())
 	gotBaseURL = client.(*gitlab.Client).BaseURL()
 	if gotBaseURL.String() != expectedGitHostBaseURL.String() {
 		t.Errorf("Expected BaseURL to be: %v, Got: %v\n", expectedGitHostBaseURL, gotBaseURL)
 	}
 
 	// Not yet supported
-	client = NewClient("notyetsupported", "")
+	client = newClient("notyetsupported", "")
 	if client != nil {
 		t.Errorf("Expected nil")
 	}

--- a/main.go
+++ b/main.go
@@ -30,8 +30,8 @@ func main() {
 	githubRepoType := flag.String("github.repoType", "all", "Repo types to backup (all, owner, member)")
 
 	// Gitlab specific flags
-	gitlabRepoVisibility := flag.String("gitlab.projectVisibility", "internal", "Visibility level of Projects to clone")
-	gitlabProjectMembership := flag.String("gitlab.projectMembershipType", "all", "Project type to clone")
+	gitlabRepoVisibility := flag.String("gitlab.projectVisibility", "internal", "Visibility level of Projects to clone (internal, public, private)")
+	gitlabProjectMembership := flag.String("gitlab.projectMembershipType", "both", "Project type to clone (owner, member, both)")
 
 	flag.Parse()
 

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ func main() {
 
 	// Gitlab specific flags
 	gitlabRepoVisibility := flag.String("gitlab.projectVisibility", "internal", "Visibility level of Projects to clone")
+	gitlabProjectMembership := flag.String("gitlab.projectMembershipType", "all", "Project type to clone")
 
 	flag.Parse()
 
@@ -40,7 +41,7 @@ func main() {
 	*backupDir = setupBackupDir(*backupDir, *service, *githostUrl)
 	tokens := make(chan bool, MAX_CONCURRENT_CLONES)
 	client := NewClient(*service, *githostUrl)
-	repos, err := getRepositories(client, *service, *githubRepoType, *gitlabRepoVisibility)
+	repos, err := getRepositories(client, *service, *githubRepoType, *gitlabRepoVisibility, *gitlabProjectMembership)
 	if err != nil {
 		log.Fatal(err)
 	} else {

--- a/main.go
+++ b/main.go
@@ -6,8 +6,9 @@ import (
 	"sync"
 )
 
-// Maximum number of concurrent clones
-var MAX_CONCURRENT_CLONES int = 20
+// MaxConcurrentClones is the upper limit of the maximum number of
+// concurrent git clones
+var MaxConcurrentClones = 20
 
 func main() {
 
@@ -23,7 +24,7 @@ func main() {
 
 	// Generic flags
 	service := flag.String("service", "", "Git Hosted Service Name (github/gitlab)")
-	githostUrl := flag.String("githost.url", "", "DNS of the custom Git host")
+	githostURL := flag.String("githost.url", "", "DNS of the custom Git host")
 	backupDir := flag.String("backupdir", "", "Backup directory")
 
 	// GitHub specific flags
@@ -38,9 +39,9 @@ func main() {
 	if len(*service) == 0 || !knownServices[*service] {
 		log.Fatal("Please specify the git service type: github, gitlab")
 	}
-	*backupDir = setupBackupDir(*backupDir, *service, *githostUrl)
-	tokens := make(chan bool, MAX_CONCURRENT_CLONES)
-	client := NewClient(*service, *githostUrl)
+	*backupDir = setupBackupDir(*backupDir, *service, *githostURL)
+	tokens := make(chan bool, MaxConcurrentClones)
+	client := newClient(*service, *githostURL)
 	repos, err := getRepositories(client, *service, *githubRepoType, *gitlabRepoVisibility, *gitlabProjectMembership)
 	if err != nil {
 		log.Fatal(err)

--- a/repositories.go
+++ b/repositories.go
@@ -7,9 +7,10 @@ import (
 	"strings"
 
 	"github.com/google/go-github/github"
-	"github.com/xanzy/go-gitlab"
+	gitlab "github.com/xanzy/go-gitlab"
 )
 
+// Response is derived from the following sources:
 // https://github.com/google/go-github/blob/27c7c32b6d369610435bd2ad7b4d8554f235eb01/github/github.go#L301
 // https://github.com/xanzy/go-gitlab/blob/3acf8d75e9de17ad4b41839a7cabbf2537760ab4/gitlab.go#L286
 type Response struct {
@@ -26,6 +27,8 @@ type Response struct {
 	LastPage  int
 }
 
+// Repository is a container for the details for a repository
+// we will backup
 type Repository struct {
 	GitURL    string
 	Name      string

--- a/repositories.go
+++ b/repositories.go
@@ -32,7 +32,7 @@ type Repository struct {
 	Namespace string
 }
 
-func getRepositories(client interface{}, service string, githubRepoType string, gitlabRepoVisibility string) ([]*Repository, error) {
+func getRepositories(client interface{}, service string, githubRepoType string, gitlabRepoVisibility string, gitlabProjectType string) ([]*Repository, error) {
 
 	if client == nil {
 		log.Fatalf("Couldn't acquire a client to talk to %s", service)
@@ -62,6 +62,9 @@ func getRepositories(client interface{}, service string, githubRepoType string, 
 
 	if service == "gitlab" {
 		var visibility gitlab.VisibilityValue
+		var owned bool
+		var memberOf bool
+
 		switch gitlabRepoVisibility {
 		case "public":
 			visibility = gitlab.PublicVisibility
@@ -72,7 +75,15 @@ func getRepositories(client interface{}, service string, githubRepoType string, 
 		case "default":
 			visibility = gitlab.InternalVisibility
 		}
-		options := gitlab.ListProjectsOptions{Visibility: &visibility}
+
+		if gitlabProjectType == "owner" {
+			owned = true
+		}
+		if gitlabProjectType == "member" {
+			memberOf = true
+		}
+		
+		options := gitlab.ListProjectsOptions{Visibility: &visibility, Membership: &memberOf, Owned: &owned}
 		for {
 			repos, resp, err := client.(*gitlab.Client).Projects.ListProjects(&options)
 			if err == nil {

--- a/repositories_test.go
+++ b/repositories_test.go
@@ -60,7 +60,7 @@ func TestGetGitHubRepositories(t *testing.T) {
 		fmt.Fprint(w, `[{"full_name": "test/r1", "id":1, "git_url": "git://github.com/u/r1", "name": "r1"}]`)
 	})
 
-	repos, err := getRepositories(GitHubClient, "github", "all", "")
+	repos, err := getRepositories(GitHubClient, "github", "all", "", "")
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -79,7 +79,7 @@ func TestGetGitLabRepositories(t *testing.T) {
 		fmt.Fprint(w, `[{"path_with_namespace": "test/r1", "id":1, "ssh_url_to_repo": "git://gitlab.com/u/r1", "name": "r1"}]`)
 	})
 
-	repos, err := getRepositories(GitLabClient, "gitlab", "internal", "")
+	repos, err := getRepositories(GitLabClient, "gitlab", "internal", "","")
 	if err != nil {
 		t.Fatalf("%v", err)
 	}


### PR DESCRIPTION
This implements a new option `gitlab.projectMembershipType`  which can take one of three values - `owner`, `member`, `both`. This allows further filtering of `gitlab` projects that you want to backup.

Implements the fix suggested in #22 and helps "fix" #19

 