### PR TITLE
gitlab project membership type: rename both to all

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Amit Saha
+Copyright (c) 2019 Amit Saha
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Usage of ./bin/gitbackup:
   -github.repoType string
         Repo types to backup (all, owner, member) (default "all")
   -gitlab.projectMembershipType string
-        Project type to clone (owner, member, both) (default "both")
+        Project type to clone (all, owner, member) (default "all")
   -gitlab.projectVisibility string
         Visibility level of Projects to clone (internal, public, private) (default "internal")
   -service string

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func main() {
 
 	// Gitlab specific flags
 	gitlabRepoVisibility := flag.String("gitlab.projectVisibility", "internal", "Visibility level of Projects to clone (internal, public, private)")
-	gitlabProjectMembership := flag.String("gitlab.projectMembershipType", "both", "Project type to clone (owner, member, both)")
+	gitlabProjectMembership := flag.String("gitlab.projectMembershipType", "all", "Project type to clone (all, owner, member)")
 
 	flag.Parse()
 
@@ -46,6 +46,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	} else {
+		log.Printf("Backing up %v repositories now..\n", len(repos))
 		for _, repo := range repos {
 			tokens <- true
 			wg.Add(1)

--- a/repositories.go
+++ b/repositories.go
@@ -77,7 +77,7 @@ func getRepositories(client interface{}, service string, githubRepoType string, 
 			memberOf = true
 		}
 
-		if gitlabProjectType == "both" {
+		if gitlabProjectType == "all" {
 			owned = true
 			memberOf = true
 		}


### PR DESCRIPTION
Further work on #25 - renaming the `both` value to `all`. This makes it consistent with github options.

Work for #22 