### PR TITLE
fix: segfault when accessing github user

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -20,7 +20,7 @@ func getUsername(client interface{}, service string) string {
 		if err != nil {
 			log.Fatal("Error retrieving username", err.Error())
 		}
-		return *user.Name
+		return *user.Login
 	}
 
 	if service == "gitlab" {


### PR DESCRIPTION
this fixes the following segfault:

    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x1294b4f]

    goroutine 1 [running]:
    main.getUsername(0x1321dc0, 0xc0001422c0, 0x7ffeefbff777, 0x6, 0x1321dc0, 0xc0001422c0)
        	/Users/jonas/projects/gitbackup/helpers.go:25 +0x13f
    main.main()
        	/Users/jonas/projects/gitbackup/main.go:53 +0x595
    exit status 2