### PR TITLE
GitHub: Intitial support for downloading user migration data

### DIFF
--- a/client.go
+++ b/client.go
@@ -110,7 +110,6 @@ func newClient(service string, gitHostURL string) interface{} {
 		if gitHostURLParsed != nil {
 			client.BaseURL = gitHostURLParsed
 		}
-		log.Printf("%#v\n", client.BaseURL)
 		return client
 	}
 

--- a/client.go
+++ b/client.go
@@ -10,7 +10,7 @@ import (
 
 	"golang.org/x/oauth2"
 
-	"github.com/google/go-github/v32/github"
+	"github.com/google/go-github/v34/github"
 	gitlab "github.com/xanzy/go-gitlab"
 
 	"github.com/99designs/keyring"
@@ -22,7 +22,7 @@ var gitbackupClientID = "7b56a77c7dfba0800524"
 
 func startOAuthFlow() string {
 	clientID := gitbackupClientID
-	scopes := []string{"repo", "read:user"}
+	scopes := []string{"repo", "user", "admin:org"}
 	httpClient := http.DefaultClient
 
 	code, err := device.RequestCode(httpClient, "https://github.com/login/device/code", clientID, scopes)
@@ -110,6 +110,7 @@ func newClient(service string, gitHostURL string) interface{} {
 		if gitHostURLParsed != nil {
 			client.BaseURL = gitHostURLParsed
 		}
+		log.Printf("%#v\n", client.BaseURL)
 		return client
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -4,7 +4,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/google/go-github/v32/github"
+	"github.com/google/go-github/v34/github"
 	gitlab "github.com/xanzy/go-gitlab"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/99designs/keyring v1.1.6
 	github.com/cli/oauth v0.8.0
-	github.com/google/go-github/v32 v32.1.0
+	github.com/google/go-github/v34 v34.0.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/afero v1.2.2
 	github.com/xanzy/go-gitlab v0.16.1

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2/go.mod h1:bBOAhwG1umN6
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/google/go-github/v32 v32.1.0 h1:GWkQOdXqviCPx7Q7Fj+KyPoGm4SwHRh8rheoPhd27II=
-github.com/google/go-github/v32 v32.1.0/go.mod h1:rIEpZD9CTDQwDK9GDrtMTycQNA4JU3qBsCizh3q2WCI=
+github.com/google/go-github/v34 v34.0.0 h1:/siYFImY8KwGc5QD1gaPf+f8QX6tLwxNIco2RkYxoFA=
+github.com/google/go-github/v34 v34.0.0/go.mod h1:w/2qlrXUfty+lbyO6tatnzIw97v1CM+/jZcwXMDiPQQ=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c h1:6rhixN/i8ZofjG1Y75iExal34USq5p+wiN1tpie8IrU=
@@ -64,7 +64,6 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7 h1:LepdCS8Gf/MVejFIt8lsiexZATdoGVyp5bcyS+rYoUI=
 golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.5 h1:i6eZZ+zk0SOf0xgBpEpPD18qWcJda6q1sxt3S0kzyUQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/helpers.go
+++ b/helpers.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"log"
 
-	"github.com/google/go-github/v32/github"
+	"github.com/google/go-github/v34/github"
 	gitlab "github.com/xanzy/go-gitlab"
 )
 

--- a/main.go
+++ b/main.go
@@ -32,10 +32,12 @@ func main() {
 	githostURL := flag.String("githost.url", "", "DNS of the custom Git host")
 	backupDir := flag.String("backupdir", "", "Backup directory")
 	ignorePrivate = flag.Bool("ignore-private", false, "Ignore private repositories/projects")
+	ignoreFork := flag.Bool("ignore-fork", false, "Ignore repositories which are forks")
 	useHTTPSClone = flag.Bool("use-https-clone", false, "Use HTTPS for cloning instead of SSH")
 
 	// GitHub specific flags
 	githubRepoType := flag.String("github.repoType", "all", "Repo types to backup (all, owner, member)")
+	githubUserData := flag.Bool("github.userData", false, "Download user data")
 
 	// Gitlab specific flags
 	gitlabRepoVisibility := flag.String("gitlab.projectVisibility", "internal", "Visibility level of Projects to clone (internal, public, private)")
@@ -47,29 +49,38 @@ func main() {
 		log.Fatal("Please specify the git service type: github, gitlab")
 	}
 	*backupDir = setupBackupDir(*backupDir, *service, *githostURL)
-	tokens := make(chan bool, MaxConcurrentClones)
+
 	client := newClient(*service, *githostURL)
 
-	gitHostUsername = getUsername(client, *service)
-
-	if len(gitHostUsername) == 0 && !*ignorePrivate && *useHTTPSClone {
-		log.Fatal("Your Git host's username is needed for backing up private repositories via HTTPS")
-	}
-	repos, err := getRepositories(client, *service, *githubRepoType, *gitlabRepoVisibility, *gitlabProjectMembership)
-	if err != nil {
-		log.Fatal(err)
+	if *githubUserData {
+		repos, err := getRepositories(client, *service, *githubRepoType, *gitlabRepoVisibility, *gitlabProjectMembership, *ignoreFork)
+		if err != nil {
+			log.Fatalf("Error getting list of repositories: %v", err)
+		}
+		getGithubUserData(client, *backupDir, repos)
 	} else {
-		log.Printf("Backing up %v repositories now..\n", len(repos))
-		for _, repo := range repos {
-			tokens <- true
-			wg.Add(1)
-			go func(repo *Repository) {
-				stdoutStderr, err := backUp(*backupDir, repo, &wg)
-				if err != nil {
-					log.Printf("Error backing up %s: %s\n", repo.Name, stdoutStderr)
-				}
-				<-tokens
-			}(repo)
+		tokens := make(chan bool, MaxConcurrentClones)
+		gitHostUsername = getUsername(client, *service)
+
+		if len(gitHostUsername) == 0 && !*ignorePrivate && *useHTTPSClone {
+			log.Fatal("Your Git host's username is needed for backing up private repositories via HTTPS")
+		}
+		repos, err := getRepositories(client, *service, *githubRepoType, *gitlabRepoVisibility, *gitlabProjectMembership, *ignoreFork)
+		if err != nil {
+			log.Fatal(err)
+		} else {
+			log.Printf("Backing up %v repositories now..\n", len(repos))
+			for _, repo := range repos {
+				tokens <- true
+				wg.Add(1)
+				go func(repo *Repository) {
+					stdoutStderr, err := backUp(*backupDir, repo, &wg)
+					if err != nil {
+						log.Printf("Error backing up %s: %s\n", repo.Name, stdoutStderr)
+					}
+					<-tokens
+				}(repo)
+			}
 		}
 	}
 }

--- a/repositories.go
+++ b/repositories.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/google/go-github/v32/github"
+	"github.com/google/go-github/v34/github"
 	gitlab "github.com/xanzy/go-gitlab"
 )
 
@@ -36,7 +36,7 @@ type Repository struct {
 	Private   bool
 }
 
-func getRepositories(client interface{}, service string, githubRepoType string, gitlabRepoVisibility string, gitlabProjectType string) ([]*Repository, error) {
+func getRepositories(client interface{}, service string, githubRepoType string, gitlabRepoVisibility string, gitlabProjectType string, ignoreFork bool) ([]*Repository, error) {
 
 	if client == nil {
 		log.Fatalf("Couldn't acquire a client to talk to %s", service)
@@ -52,6 +52,9 @@ func getRepositories(client interface{}, service string, githubRepoType string, 
 			repos, resp, err := client.(*github.Client).Repositories.List(ctx, "", &options)
 			if err == nil {
 				for _, repo := range repos {
+					if *repo.Fork && ignoreFork {
+						continue
+					}
 					namespace := strings.Split(*repo.FullName, "/")[0]
 					if useHTTPSClone != nil && *useHTTPSClone {
 						cloneURL = *repo.CloneURL

--- a/repositories_test.go
+++ b/repositories_test.go
@@ -10,7 +10,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/go-github/v32/github"
+	"github.com/google/go-github/v34/github"
 	gitlab "github.com/xanzy/go-gitlab"
 )
 

--- a/repositories_test.go
+++ b/repositories_test.go
@@ -57,10 +57,10 @@ func TestGetPublicGitHubRepositories(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/user/repos", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, `[{"full_name": "test/r1", "id":1, "ssh_url": "https://github.com/u/r1", "name": "r1", "private": false}]`)
+		fmt.Fprint(w, `[{"full_name": "test/r1", "id":1, "ssh_url": "https://github.com/u/r1", "name": "r1", "private": false, "fork": false}]`)
 	})
 
-	repos, err := getRepositories(GitHubClient, "github", "all", "", "")
+	repos, err := getRepositories(GitHubClient, "github", "all", "", "", false)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -76,10 +76,10 @@ func TestGetPrivateGitHubRepositories(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/user/repos", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, `[{"full_name": "test/r1", "id":1, "ssh_url": "https://github.com/u/r1", "name": "r1", "private": true}]`)
+		fmt.Fprint(w, `[{"full_name": "test/r1", "id":1, "ssh_url": "https://github.com/u/r1", "name": "r1", "private": true, "fork": false}]`)
 	})
 
-	repos, err := getRepositories(GitHubClient, "github", "all", "", "")
+	repos, err := getRepositories(GitHubClient, "github", "all", "", "", false)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -98,7 +98,7 @@ func TestGetGitLabRepositories(t *testing.T) {
 		fmt.Fprint(w, `[{"path_with_namespace": "test/r1", "id":1, "ssh_url_to_repo": "https://gitlab.com/u/r1", "name": "r1"}]`)
 	})
 
-	repos, err := getRepositories(GitLabClient, "gitlab", "internal", "", "")
+	repos, err := getRepositories(GitLabClient, "gitlab", "internal", "", "", false)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}

--- a/user_data.go
+++ b/user_data.go
@@ -84,6 +84,7 @@ func downloadGithubUserData(client interface{}, backupDir string, id *int64) {
 	}
 }
 
+// Type for listing migration result
 type ListGithubUserMigrationsResult struct {
 	GUID  *string `json:"guid"`
 	ID    *int64  `json:"id"`
@@ -121,11 +122,13 @@ func GetGithubUserMigration(client interface{}, id *int64) (*github.UserMigratio
 	return ms, err
 }
 
+// Type for deletion result
 type GithubUserMigrationDeleteResult struct {
 	GhStatusCode   int    `json:"status_code"`
 	GhResponseBody string `json:"mesage"`
 }
 
+// Delete an existing migration
 func DeleteGithubUserMigration(id *int64) GithubUserMigrationDeleteResult {
 	client := newClient("github", "https://github.com")
 	ctx := context.Background()

--- a/user_data.go
+++ b/user_data.go
@@ -84,7 +84,7 @@ func downloadGithubUserData(client interface{}, backupDir string, id *int64) {
 	}
 }
 
-// ListGithubUserMigrationResult type is for listing migration result
+// ListGithubUserMigrationsResult type is for listing migration result
 type ListGithubUserMigrationsResult struct {
 	GUID  *string `json:"guid"`
 	ID    *int64  `json:"id"`

--- a/user_data.go
+++ b/user_data.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"time"
+
+	"github.com/google/go-github/v34/github"
+)
+
+func createGithubUserMigration(ctx context.Context, client *github.Client, repos []string) (*github.UserMigration, error) {
+	migrationOpts := github.UserMigrationOptions{
+		LockRepositories:   false,
+		ExcludeAttachments: false,
+	}
+	m, _, err := client.Migrations.StartUserMigration(ctx, repos, &migrationOpts)
+	return m, err
+}
+
+func getGithubUserData(client interface{}, backupDir string, repos []*Repository) {
+
+	var ms *github.UserMigration
+	ctx := context.Background()
+
+	var repoPaths []string
+	for _, repo := range repos {
+		repoPaths = append(repoPaths, fmt.Sprintf("%s/%s", repo.Namespace, repo.Name))
+	}
+	m, err := createGithubUserMigration(ctx, client.(*github.Client), repoPaths)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ms, _, err = client.(*github.Client).Migrations.UserMigrationStatus(ctx, *m.ID)
+	if err != nil {
+		panic(err)
+	}
+
+	var result GithubUserMigrationState
+	result.ID = ms.ID
+	result.State = ms.State
+	result.CreatedAt = ms.CreatedAt
+	result.UpdatedAt = ms.UpdatedAt
+
+	for {
+
+		// URL can be null since GitHub only keeps the archive URL for 7 days
+		if *ms.State == "exported" {
+			log.Printf("Migration state: %v\n", ms.State)
+			archiveURL, err := client.(*github.Client).Migrations.UserMigrationArchiveURL(ctx, *ms.ID)
+			if err != nil {
+				panic(err)
+			}
+			result.ArchiveURL = &archiveURL
+			parsedURL, _ := url.Parse(archiveURL)
+			archiveFilepath := path.Join(backupDir, parsedURL.EscapedPath())
+			log.Printf("Downloading file to: %s\n", archiveFilepath)
+
+			resp, err := http.Get(archiveURL)
+			if err != nil {
+				log.Fatal(err)
+			}
+			defer resp.Body.Close()
+
+			out, err := os.Create(archiveFilepath)
+			if err != nil {
+				log.Fatal(err)
+			}
+			defer out.Close()
+
+			_, err = io.Copy(out, resp.Body)
+			if err != nil {
+				log.Fatal(err)
+			}
+			break
+		} else {
+			log.Printf("Waiting for migration state to be exported: %v\n", ms.State)
+			time.Sleep(30 * time.Second)
+
+			ms, _, err = client.(*github.Client).Migrations.UserMigrationStatus(ctx, *m.ID)
+			if err != nil {
+				panic(err)
+			}
+		}
+	}
+}
+
+type ListGithubUserMigrationsResult struct {
+	GUID  *string `json:"guid"`
+	ID    *int64  `json:"id"`
+	State *string `json:"state"`
+}
+
+// List Github user migrations
+func getGithubUserMigrations(client *github.Client) []ListGithubUserMigrationsResult {
+
+	ctx := context.Background()
+	migrations, _, err := client.Migrations.ListUserMigrations(ctx)
+
+	if err != nil {
+		panic(err)
+	}
+
+	var result []ListGithubUserMigrationsResult
+	for _, m := range migrations {
+
+		r := ListGithubUserMigrationsResult{}
+		r.GUID = m.GUID
+		r.ID = m.ID
+		r.State = m.State
+
+		result = append(result, r)
+	}
+
+	return result
+}
+
+type GithubUserMigrationState struct {
+	ID         *int64  `json:"id"`
+	CreatedAt  *string `json:"created_at"`
+	UpdatedAt  *string `json:"updated_at"`
+	State      *string `json:"state"`
+	ArchiveURL *string `json:"archive_url"`
+}
+
+// Get the status of a migration
+func GetGithubUserMigration(id *int64) GithubUserMigrationState {
+	client := newClient("github", "https://github.com")
+	ctx := context.Background()
+	ms, _, err := client.(*github.Client).Migrations.UserMigrationStatus(ctx, *id)
+
+	if err != nil {
+		panic(err)
+	}
+	var result GithubUserMigrationState
+	result.ID = ms.ID
+	result.State = ms.State
+	result.CreatedAt = ms.CreatedAt
+	result.UpdatedAt = ms.UpdatedAt
+
+	// URL can be null since GitHub only keeps the archive URL for 7 days
+	if *ms.State == "exported" {
+		url, err := client.(*github.Client).Migrations.UserMigrationArchiveURL(ctx, *id)
+		if err != nil {
+			panic(err)
+		}
+		result.ArchiveURL = &url
+	}
+
+	return result
+}
+
+type GithubUserMigrationDeleteResult struct {
+	GhStatusCode   int    `json:"status_code"`
+	GhResponseBody string `json:"mesage"`
+}
+
+func DeleteGithubUserMigration(id *int64) GithubUserMigrationDeleteResult {
+	client := newClient("github", "https://github.com")
+	ctx := context.Background()
+	response, err := client.(*github.Client).Migrations.DeleteUserMigration(ctx, *id)
+
+	result := GithubUserMigrationDeleteResult{}
+	result.GhStatusCode = response.StatusCode
+
+	if err != nil {
+		result.GhResponseBody = err.Error()
+	} else {
+
+		data, err := ioutil.ReadAll(response.Body)
+		if err != nil {
+			panic(err)
+		}
+		result.GhResponseBody = string(data)
+	}
+	return result
+}

--- a/user_data.go
+++ b/user_data.go
@@ -84,7 +84,7 @@ func downloadGithubUserData(client interface{}, backupDir string, id *int64) {
 	}
 }
 
-// Type for listing migration result
+// ListGithubUserMigrationResult type is for listing migration result
 type ListGithubUserMigrationsResult struct {
 	GUID  *string `json:"guid"`
 	ID    *int64  `json:"id"`
@@ -115,20 +115,20 @@ func getGithubUserMigrations(client interface{}) ([]ListGithubUserMigrationsResu
 	return result, nil
 }
 
-// Get the status of a migration
+// GetGithubUserMigration to Get the status of a migration
 func GetGithubUserMigration(client interface{}, id *int64) (*github.UserMigration, error) {
 	ctx := context.Background()
 	ms, _, err := client.(*github.Client).Migrations.UserMigrationStatus(ctx, *id)
 	return ms, err
 }
 
-// Type for deletion result
+// GithubUserMigrationDeleteResult is a type for deletion result
 type GithubUserMigrationDeleteResult struct {
 	GhStatusCode   int    `json:"status_code"`
 	GhResponseBody string `json:"mesage"`
 }
 
-// Delete an existing migration
+// DeleteGithubUserMigration deletes an existing migration
 func DeleteGithubUserMigration(id *int64) GithubUserMigrationDeleteResult {
 	client := newClient("github", "https://github.com")
 	ctx := context.Background()


### PR DESCRIPTION
This PR adds initial support for working with [GitHub user migrations](https://docs.github.com/en/rest/reference/migrations#user). It adds support for:

- Creating a user migration and downloading the migration archive
- Listing existing migrations

Issue: https://github.com/amitsaha/gitbackup/issues/20 