### PR TITLE
Add support for bare repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Usage of ./bin/gitbackup:
     	Git Hosted Service Name (github/gitlab)
   -use-https-clone
     	Use HTTPS for cloning instead of SSH
+  -bare
+    	Clone bare repositories instead of working directories
 ```
 ### Backing up your GitHub repositories
 
@@ -148,6 +150,17 @@ $ GITHUB_TOKEN=secret$token gitbackup -service github -backupdir /data/
 This will create a ``github.com`` directory in ``/data`` and backup all your repositories there instead.
 Similarly, it will create a ``gitlab.com`` directory, if you are backing up repositories from ``gitlab``.
 If you have specified a Git Host URL, it will create a directory structure ``data/host-url/``.
+
+
+### Cloning bare repositories
+
+To clone bare repositories, we can use the ``bare`` flag:
+
+```lang=bash
+$ GITHUB_TOKEN=secret$token gitbackup -service github -bare
+```
+
+This will create a directory structure like ``github.com/org/repo.git`` containing bare repositories.
 
 
 ## Building

--- a/backup_test.go
+++ b/backup_test.go
@@ -27,6 +27,14 @@ func fakeCloneCommand(command string, args ...string) (cmd *exec.Cmd) {
 	return cmd
 }
 
+func fakeRemoteUpdateCommand(command string, args ...string) (cmd *exec.Cmd) {
+	cs := []string{"-test.run=TestHelperRemoteUpdateProcess", "--", command}
+	cs = append(cs, args...)
+	cmd = exec.Command(os.Args[0], cs...)
+	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
+	return cmd
+}
+
 func TestBackup(t *testing.T) {
 	var wg sync.WaitGroup
 	repo := Repository{Name: "testrepo", CloneURL: "git://foo.com/foo"}
@@ -44,7 +52,7 @@ func TestBackup(t *testing.T) {
 	// Test clone
 	execCommand = fakeCloneCommand
 	wg.Add(1)
-	stdoutStderr, err := backUp(backupDir, &repo, &wg)
+	stdoutStderr, err := backUp(backupDir, &repo, false, &wg)
 	if err != nil {
 		t.Errorf("%s", stdoutStderr)
 	}
@@ -54,11 +62,43 @@ func TestBackup(t *testing.T) {
 	appFS.MkdirAll(repoDir, 0771)
 	execCommand = fakePullCommand
 	wg.Add(1)
-	stdoutStderr, err = backUp(backupDir, &repo, &wg)
+	stdoutStderr, err = backUp(backupDir, &repo, false, &wg)
+	if err != nil {
+		t.Errorf("%s", stdoutStderr)
+	}
+}
+
+func TestBareBackup(t *testing.T) {
+	var wg sync.WaitGroup
+	repo := Repository{Name: "testrepo", CloneURL: "git://foo.com/foo"}
+	backupDir := "/tmp/backupdir"
+
+	// Memory FS
+	appFS = afero.NewMemMapFs()
+	appFS.MkdirAll(backupDir, 0771)
+
+	defer func() {
+		execCommand = exec.Command
+		wg.Wait()
+	}()
+
+	// Test clone
+	execCommand = fakeCloneCommand
+	wg.Add(1)
+	stdoutStderr, err := backUp(backupDir, &repo, true, &wg)
 	if err != nil {
 		t.Errorf("%s", stdoutStderr)
 	}
 
+	// Test pull
+	repoDir := path.Join(backupDir, repo.Name+".git")
+	appFS.MkdirAll(repoDir, 0771)
+	execCommand = fakeRemoteUpdateCommand
+	wg.Add(1)
+	stdoutStderr, err = backUp(backupDir, &repo, true, &wg)
+	if err != nil {
+		t.Errorf("%s", stdoutStderr)
+	}
 }
 
 func TestHelperPullProcess(t *testing.T) {
@@ -80,6 +120,18 @@ func TestHelperCloneProcess(t *testing.T) {
 	// Check that git command was executed
 	if os.Args[3] != "git" || os.Args[4] != "clone" {
 		fmt.Fprintf(os.Stdout, "Expected git clone to be executed. Got %v", os.Args[3:])
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+func TestHelperRemoteUpdateProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	// Check that git command was executed
+	if os.Args[3] != "git" || os.Args[6] != "remote" || os.Args[7] != "update" {
+		fmt.Fprintf(os.Stdout, "Expected git remote update to be executed. Got %v", os.Args[3:])
 		os.Exit(1)
 	}
 	os.Exit(0)

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ func main() {
 	ignorePrivate = flag.Bool("ignore-private", false, "Ignore private repositories/projects")
 	ignoreFork := flag.Bool("ignore-fork", false, "Ignore repositories which are forks")
 	useHTTPSClone = flag.Bool("use-https-clone", false, "Use HTTPS for cloning instead of SSH")
+	bare := flag.Bool("bare", false, "Clone bare repositories")
 
 	// GitHub specific flags
 	githubRepoType := flag.String("github.repoType", "all", "Repo types to backup (all, owner, member)")
@@ -144,7 +145,7 @@ func main() {
 				tokens <- true
 				wg.Add(1)
 				go func(repo *Repository) {
-					stdoutStderr, err := backUp(*backupDir, repo, &wg)
+					stdoutStderr, err := backUp(*backupDir, repo, *bare, &wg)
 					if err != nil {
 						log.Printf("Error backing up %s: %s\n", repo.Name, stdoutStderr)
 					}


### PR DESCRIPTION
Fixes #31 , based on @jvmatl's work.

I called it `bare` to match Git vocabulary though.

Repos will be cloned to `reponame.git`.