### PR TITLE
Fix #62 - GitHub user migration retry

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/url"
 	"sync"
+	"time"
 
 	"github.com/google/go-github/v34/github"
 )
@@ -49,7 +50,7 @@ func main() {
 	githubRepoType := flag.String("github.repoType", "all", "Repo types to backup (all, owner, member, starred)")
 
 	githubCreateUserMigration := flag.Bool("github.createUserMigration", false, "Download user data")
-
+	githubCreateUserMigrationRetry := flag.Bool("github.createUserMigrationRetry", true, "Retry creating the user migration if we get an error")
 	githubListUserMigrations := flag.Bool("github.listUserMigrations", false, "List available user migrations")
 	githubWaitForMigrationComplete := flag.Bool("github.waitForUserMigration", true, "Wait for migration to complete")
 
@@ -115,7 +116,15 @@ func main() {
 		log.Printf("Creating a user migration for %d repos", len(repos))
 		m, err := createGithubUserMigration(context.Background(), client, repos)
 		if err != nil {
-			log.Fatalf("Error creating migration: %v", err)
+			if !*githubCreateUserMigrationRetry {
+				log.Fatalf("Error creating migration: %v", err)
+			}
+			log.Printf("Got error when creating migration: %v. Retrying after sleeping for 300 seconds.", err)
+			time.Sleep(300 * time.Second)
+			m, err = createGithubUserMigration(context.Background(), client, repos)
+			if err != nil {
+				log.Fatalf("Error creating migration: %v", err)
+			}
 		}
 		if *githubWaitForMigrationComplete {
 			downloadGithubUserMigrationData(client, *backupDir, m.ID)


### PR DESCRIPTION
Attempt at creating a user migration after 5 minutes, if it fails. This is of course quick and dirty to validate if this will work.

The interesting thing is the migration does work on the GitHub side, since i get an email saying the migration is ready and I can download it.