### PR TITLE
Fix private repo cloning

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -45,7 +45,7 @@ func backUp(backupDir string, repo *Repository, bare bool, wg *sync.WaitGroup) (
 		log.Printf("Cloning %s\n", repo.Name)
 		log.Printf("%#v\n", repo)
 
-		if repo.Private && useHTTPSClone != nil && *useHTTPSClone && ignorePrivate != nil && !*ignorePrivate {
+		if useHTTPSClone != nil && *useHTTPSClone && ignorePrivate != nil && !*ignorePrivate {
 			// Add username and token to the clone URL
 			// https://gitlab.com/amitsaha/testproject1 => https://amitsaha:token@gitlab.com/amitsaha/testproject1
 			u, err := url.Parse(repo.CloneURL)

--- a/backup.go
+++ b/backup.go
@@ -45,7 +45,12 @@ func backUp(backupDir string, repo *Repository, bare bool, wg *sync.WaitGroup) (
 		log.Printf("Cloning %s\n", repo.Name)
 		log.Printf("%#v\n", repo)
 
-		if useHTTPSClone != nil && *useHTTPSClone && ignorePrivate != nil && !*ignorePrivate {
+		if repo.Private && ignorePrivate != nil && !*ignorePrivate {
+			log.Printf("Skipping %s as it is a private repo.\n", repo.Name)
+			return stdoutStderr, nil
+		}
+
+		if useHTTPSClone != nil && *useHTTPSClone {
 			// Add username and token to the clone URL
 			// https://gitlab.com/amitsaha/testproject1 => https://amitsaha:token@gitlab.com/amitsaha/testproject1
 			u, err := url.Parse(repo.CloneURL)


### PR DESCRIPTION
I separated the private repo check & https cloning as it made no sense (to me) to combine these two checks. On GitLab the `repo.Private` always seems to be `false` which prevented the `useHttpsClone` from being applied.

Tested locally on Gitlab.com and cloning private repos works fine now.