### PR TITLE
Gitlab: Fix private repo discovery

### DIFF
--- a/repositories.go
+++ b/repositories.go
@@ -152,7 +152,7 @@ func getRepositories(client interface{},
 				} else {
 					cloneURL = repo.SSHURLToRepo
 				}
-				repositories = append(repositories, &Repository{CloneURL: cloneURL, Name: repo.Name, Namespace: namespace, Private: repo.Public})
+				repositories = append(repositories, &Repository{CloneURL: cloneURL, Name: repo.Name, Namespace: namespace, Private: repo.Visibility == "private"})
 			}
 			if resp.NextPage == 0 {
 				break

--- a/repositories_test.go
+++ b/repositories_test.go
@@ -138,6 +138,32 @@ func TestGetGitLabRepositories(t *testing.T) {
 	}
 }
 
+func TestGetGitLabPrivateRepositories(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/api/v4/projects", func(w http.ResponseWriter,
+		r *http.Request) {
+		fmt.Fprint(w, `[{"path_with_namespace": "test/r1",
+"id":1, "ssh_url_to_repo": "https://gitlab.com/u/r1", "name": "r1",
+"visibility": "private"}]`)
+	})
+
+	repos, err := getRepositories(GitLabClient, "gitlab",
+		"private", "", "", false)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	var expected []*Repository
+	expected = append(expected, &Repository{Namespace: "test",
+		CloneURL: "https://gitlab.com/u/r1", Name: "r1", Private: true})
+	if !reflect.DeepEqual(repos, expected) {
+		for i := 0; i < len(repos); i++ {
+			t.Errorf("Expected %+v, Got %+v", expected[i], repos[i])
+		}
+	}
+}
+
 func TestGetStarredGitLabRepositories(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
The `Public` attribute from go-gitlab is not configured correctly, so we simply use the `Visibility` attribute.