### PR TITLE
Fix Bug ignore private repo logic

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -45,7 +45,7 @@ func backUp(backupDir string, repo *Repository, bare bool, wg *sync.WaitGroup) (
 		log.Printf("Cloning %s\n", repo.Name)
 		log.Printf("%#v\n", repo)
 
-		if repo.Private && ignorePrivate != nil && !*ignorePrivate {
+		if repo.Private && ignorePrivate != nil && *ignorePrivate {
 			log.Printf("Skipping %s as it is a private repo.\n", repo.Name)
 			return stdoutStderr, nil
 		}


### PR DESCRIPTION
In line 48 if expression had a bug: private repos would be skipped if `ignorePrivate` is false.