### PR TITLE
Fix bug introduced in backup directory creation

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -75,7 +75,7 @@ func setupBackupDir(backupDir, service, githostURL *string) string {
 	var gitHost, backupPath string
 	var err error
 
-	if githostURL != nil {
+	if len(*githostURL) != 0 {
 		u, err := url.Parse(*githostURL)
 		if err != nil {
 			panic(err)
@@ -83,9 +83,10 @@ func setupBackupDir(backupDir, service, githostURL *string) string {
 		gitHost = u.Host
 	} else {
 		gitHost = knownServices[*service]
+		log.Println("knownservices", gitHost)
 	}
 
-	if backupDir == nil {
+	if len(*backupDir) == 0 {
 		homeDir, err := homedir.Dir()
 		if err == nil {
 			backupPath = path.Join(homeDir, ".gitbackup", gitHost)
@@ -95,9 +96,10 @@ func setupBackupDir(backupDir, service, githostURL *string) string {
 	} else {
 		backupPath = path.Join(*backupDir, gitHost)
 	}
+
 	err = createBackupRootDirIfRequired(backupPath)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("Error creating backup directory: %s %v", backupPath, err)
 	}
 	return backupPath
 }

--- a/backup_test.go
+++ b/backup_test.go
@@ -158,64 +158,64 @@ func TestSetupBackupDir(t *testing.T) {
 	serviceGitlabCustomUrl := "https://company.gitlab.com"
 
 	var testConfigs = []struct {
-		backupRootDir  *string
+		backupRootDir  string
 		gitService     string
-		gitServiceUrl  *string
+		gitServiceUrl  string
 		wantBackupPath string
 	}{
 		{
-			nil,
+			"",
 			"github",
-			nil,
+			"",
 			"/home/fakeuser/.gitbackup/github.com",
 		},
 		{
-			&backupRoot,
+			backupRoot,
 			"github",
-			nil,
+			"",
 			"/my/backup/root/github.com",
 		},
 		{
-			&backupRoot,
+			backupRoot,
 			"github",
-			&serviceGithubCustomUrl,
+			serviceGithubCustomUrl,
 			"/my/backup/root/company.github.com",
 		},
 		{
-			nil,
+			"",
 			"gitlab",
-			nil,
+			"",
 			"/home/fakeuser/.gitbackup/gitlab.com",
 		},
 
 		{
-			&backupRoot,
+			backupRoot,
 			"gitlab",
-			nil,
+			"",
 			"/my/backup/root/gitlab.com",
 		},
 		{
-			&backupRoot,
+			backupRoot,
 			"gitlab",
-			&serviceGitlabCustomUrl,
+			serviceGitlabCustomUrl,
 			"/my/backup/root/company.gitlab.com",
 		},
 		{
-			&backupRoot,
+			backupRoot,
 			"bitbucket",
-			nil,
+			"",
 			"/my/backup/root/bitbucket.org",
 		},
 		{
-			nil,
+			"",
 			"bitbucket",
-			nil,
+			"",
 			"/home/fakeuser/.gitbackup/bitbucket.org",
 		},
 	}
 
 	for _, tc := range testConfigs {
-		backupdir := setupBackupDir(tc.backupRootDir, &tc.gitService, tc.gitServiceUrl)
+		backupdir := setupBackupDir(&tc.backupRootDir, &tc.gitService, &tc.gitServiceUrl)
 		if backupdir != tc.wantBackupPath {
 			t.Errorf("Expected %s, Got %s", tc.wantBackupPath, backupdir)
 		}


### PR DESCRIPTION
I introduced a bug in the previous commit misremembering the behavior of `flag.(..)` functions.