### PR TITLE
Add users/orgs whitelist flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Usage of ./gitbackup:
         Number of retries to attempt for creating GitHub user migration (default 5)
   -github.listUserMigrations
         List available user migrations
+  -github.namespaceWhitelist string
+        Organizations/Users from where we should clone (separate each value by a comma: 'user1,org2')
   -github.repoType string
         Repo types to backup (all, owner, member, starred) (default "all")
   -github.waitForUserMigration
@@ -159,6 +161,12 @@ Separately, to backup GitHub repositories you have starred:
 
 ```lang=bash
 $ GITHUB_TOKEN=secret$token gitbackup -service github -github.repoType starred
+```
+
+Additionally, to backup only the GitHub repositories under 'user1' and 'org3':
+
+```lang=bash
+$ GITHUB_TOKEN=secret$token gitbackup -service github -github.namespaceWhitelist "user1,org3"
 ```
 
 #### Backing up your GitLab repositories

--- a/helpers.go
+++ b/helpers.go
@@ -52,3 +52,12 @@ func validGitlabProjectMembership(membership string) bool {
 	}
 	return false
 }
+
+func contains(list []string, x string) bool {
+	for _, item := range list {
+		if item == x {
+			return true
+		}
+	}
+	return false
+}

--- a/repositories.go
+++ b/repositories.go
@@ -38,7 +38,7 @@ type Repository struct {
 }
 
 func getRepositories(client interface{},
-	service string, githubRepoType string,
+	service string, githubRepoType string, githubNamespaceWhitelist []string,
 	gitlabProjectVisibility string, gitlabProjectMembershipType string,
 	ignoreFork bool,
 ) ([]*Repository, error) {
@@ -80,6 +80,8 @@ func getRepositories(client interface{},
 			}
 		} else {
 			options := github.RepositoryListOptions{Type: githubRepoType}
+			githubNamespaceWhitelistLength := len(githubNamespaceWhitelist)
+
 			for {
 				repos, resp, err := client.(*github.Client).Repositories.List(ctx, "", &options)
 				if err == nil {
@@ -88,6 +90,11 @@ func getRepositories(client interface{},
 							continue
 						}
 						namespace := strings.Split(*repo.FullName, "/")[0]
+
+						if githubNamespaceWhitelistLength > 0 && !contains(githubNamespaceWhitelist, namespace) {
+							continue
+						}
+
 						if useHTTPSClone != nil && *useHTTPSClone {
 							cloneURL = *repo.CloneURL
 						} else {


### PR DESCRIPTION
# Description

- Add support for a users/orgs whitelist flag (`-github.namespaceWhitelist`), so we can filter from which organizations or users we want to backup the repositories.
- It will ignore all repositories that are not on the whitelist flag.
- If this flag is not set, it will not apply any filter.