### PR TITLE
Add a test for the command's usage message

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,11 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
       - run: go test
+      - name: Archive testdata for diagnosis
+        uses: actions/upload-artifact@v3
+        with:
+          name: testdata
+          path: testdata
   
   macos_tests:
     runs-on: macOS-latest
@@ -32,6 +37,11 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
       - run: go test
+      - name: Archive testdata for diagnosis
+        uses: actions/upload-artifact@v3
+        with:
+          name: testdata
+          path: testdata
   
   windows_tests:
     runs-on: windows-latest
@@ -44,4 +54,9 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go }}
-      - run: go test  
+      - run: go test
+      - name: Archive testdata for diagnosis
+        uses: actions/upload-artifact@v3
+        with:
+          name: testdata
+          path: testdata

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,10 @@ jobs:
           go-version: ${{ matrix.go }}
       - run: go test
       - name: Archive testdata for diagnosis
+        if: ${{ always() }}
         uses: actions/upload-artifact@v3
         with:
-          name: testdata
+          name: testdata-linux
           path: testdata
   
   macos_tests:
@@ -38,9 +39,10 @@ jobs:
           go-version: ${{ matrix.go }}
       - run: go test
       - name: Archive testdata for diagnosis
+        if: ${{ always() }}
         uses: actions/upload-artifact@v3
         with:
-          name: testdata
+          name: testdata-macos
           path: testdata
   
   windows_tests:
@@ -56,7 +58,8 @@ jobs:
           go-version: ${{ matrix.go }}
       - run: go test
       - name: Archive testdata for diagnosis
+        if: ${{ always() }}
         uses: actions/upload-artifact@v3
         with:
-          name: testdata
+          name: testdata-windows
           path: testdata

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ gitbackup
 
 #
 dist/
+
+testdata/**expected

--- a/backup.go
+++ b/backup.go
@@ -7,7 +7,7 @@ import (
 	"path"
 	"sync"
 
-	homedir "github.com/mitchellh/go-homedir"
+	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/afero"
 )
 
@@ -15,6 +15,7 @@ import (
 var execCommand = exec.Command
 var appFS = afero.NewOsFs()
 var gitCommand = "git"
+var gethomeDir = homedir.Dir
 
 // Check if we have a copy of the repo already, if
 // we do, we update the repo, else we do a fresh clone
@@ -86,7 +87,7 @@ func setupBackupDir(backupDir, service, githostURL *string) string {
 	}
 
 	if len(*backupDir) == 0 {
-		homeDir, err := homedir.Dir()
+		homeDir, err := gethomeDir()
 		if err == nil {
 			backupPath = path.Join(homeDir, ".gitbackup", gitHost)
 		} else {

--- a/backup_test.go
+++ b/backup_test.go
@@ -11,17 +11,6 @@ import (
 	"github.com/spf13/afero"
 )
 
-func setupBackupDirTests() {
-	os.Setenv("HOME", "/home/fakeuser")
-	os.Setenv("home", "/home/fakeuser")
-	appFS = afero.NewMemMapFs()
-}
-
-func teardownBackupDirTests() {
-	os.Unsetenv("HOME")
-	os.Unsetenv("home")
-}
-
 func fakePullCommand(command string, args ...string) (cmd *exec.Cmd) {
 	cs := []string{"-test.run=TestHelperPullProcess", "--", command}
 	cs = append(cs, args...)
@@ -149,8 +138,12 @@ func TestHelperRemoteUpdateProcess(t *testing.T) {
 }
 
 func TestSetupBackupDir(t *testing.T) {
-	setupBackupDirTests()
-	defer teardownBackupDirTests()
+
+	// test implementation of homedir.Dir()
+	gethomeDir = func() (string, error) {
+		return "/home/fakeuser", nil
+	}
+	appFS = afero.NewMemMapFs()
 
 	backupRoot := "/my/backup/root"
 

--- a/cli_test.go
+++ b/cli_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func TestCli(t *testing.T) {
+	cmd := exec.Command("go", "build", "-o", "gitbackup_test_bin")
+	stdoutStderr, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		err := os.Remove("gitbackup_test_bin")
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+	cmd = exec.Command("./gitbackup_test_bin", "-h")
+	stdoutStderr, err = cmd.CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(string(stdoutStderr))
+}

--- a/cli_test.go
+++ b/cli_test.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"reflect"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -54,6 +55,10 @@ func TestCliUsage(t *testing.T) {
 		}
 		t.FailNow()
 	}
+	expectedUsageString := string(expectedUsage)
+	// For windows
+	expectedUsage = []byte(strings.ReplaceAll(expectedUsageString, "\r\n", "\n"))
+
 	if !reflect.DeepEqual(expectedUsage, gotUsage) {
 		t.Errorf("expected and got data mismatch. ..writing expected output to %[1]s", goldenFilepathNew)
 		if err := writeExpectedGoldenFile(goldenFilepathNew, gotUsage); err != nil {

--- a/cli_test.go
+++ b/cli_test.go
@@ -1,16 +1,25 @@
 package main
 
 import (
+	"bytes"
+	"log"
 	"os"
 	"os/exec"
+	"path"
+	"reflect"
 	"testing"
 )
 
-func TestCli(t *testing.T) {
-	cmd := exec.Command("go", "build", "-o", "gitbackup_test_bin")
+func TestCliUsage(t *testing.T) {
+	cmd := exec.Command("go", "env")
 	stdoutStderr, err := cmd.CombinedOutput()
+	t.Log(cmd.Environ())
+	t.Fatalf(string(stdoutStderr))
+
+	cmd = exec.Command("go", "build", "-v", "-o", "gitbackup_test_bin")
+	stdoutStderr, err = cmd.CombinedOutput()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("Error building test binary: %v - %v", err, string(stdoutStderr))
 	}
 	defer func() {
 		err := os.Remove("gitbackup_test_bin")
@@ -18,10 +27,39 @@ func TestCli(t *testing.T) {
 			t.Fatal(err)
 		}
 	}()
+
+	var stdout, stderr bytes.Buffer
+	goldenFilepath := path.Join("testdata", t.Name()+".golden")
+	goldenFilepathNew := goldenFilepath + ".expected"
+
 	cmd = exec.Command("./gitbackup_test_bin", "-h")
-	stdoutStderr, err = cmd.CombinedOutput()
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err = cmd.Run()
 	if err != nil {
+		log.Println(string(stderr.Bytes()))
 		t.Fatal(err)
 	}
-	t.Log(string(stdoutStderr))
+
+	gotUsage := stderr.Bytes()
+
+	expectedUsage, err := os.ReadFile(goldenFilepath)
+	if err != nil {
+		t.Errorf("couldn't read %[1]s..writing expected output to %[1]s", goldenFilepath)
+		if err := writeExpectedGoldenFile(goldenFilepath, gotUsage); err != nil {
+			t.Fatal("Error writing file", err)
+		}
+		t.FailNow()
+	}
+	if !reflect.DeepEqual(expectedUsage, gotUsage) {
+		t.Errorf("expected and got data mismatch. ..writing expected output to %[1]s", goldenFilepathNew)
+		if err := writeExpectedGoldenFile(goldenFilepathNew, gotUsage); err != nil {
+			t.Fatal("Error writing file", err)
+		}
+		t.FailNow()
+	}
+}
+
+func writeExpectedGoldenFile(filePath string, data []byte) error {
+	return os.WriteFile(filePath, data, 0644)
 }

--- a/cli_test.go
+++ b/cli_test.go
@@ -13,8 +13,10 @@ import (
 
 func TestCliUsage(t *testing.T) {
 	binaryFilename := "gitbackup_test_bin"
+	goldenFilepath := path.Join("testdata", t.Name()+".golden")
 	if runtime.GOOS == "windows" {
 		binaryFilename = "gitbackup_test_bin.exe"
+		goldenFilepath = goldenFilepath + ".windows"
 	}
 
 	cmd := exec.Command("go", "build", "-o", binaryFilename)
@@ -30,7 +32,6 @@ func TestCliUsage(t *testing.T) {
 	}()
 
 	var stdout, stderr bytes.Buffer
-	goldenFilepath := path.Join("testdata", t.Name()+".golden")
 	goldenFilepathNew := goldenFilepath + ".expected"
 
 	cmd = exec.Command("./"+binaryFilename, "-h")

--- a/cli_test.go
+++ b/cli_test.go
@@ -11,13 +11,8 @@ import (
 )
 
 func TestCliUsage(t *testing.T) {
-	cmd := exec.Command("go", "env")
+	cmd := exec.Command("go", "build", "-o", "gitbackup_test_bin")
 	stdoutStderr, err := cmd.CombinedOutput()
-	t.Log(cmd.Environ())
-	t.Fatalf(string(stdoutStderr))
-
-	cmd = exec.Command("go", "build", "-v", "-o", "gitbackup_test_bin")
-	stdoutStderr, err = cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("Error building test binary: %v - %v", err, string(stdoutStderr))
 	}

--- a/cli_test.go
+++ b/cli_test.go
@@ -7,17 +7,23 @@ import (
 	"os/exec"
 	"path"
 	"reflect"
+	"runtime"
 	"testing"
 )
 
 func TestCliUsage(t *testing.T) {
-	cmd := exec.Command("go", "build", "-o", "gitbackup_test_bin")
+	binaryFilename := "gitbackup_test_bin"
+	if runtime.GOOS == "windows" {
+		binaryFilename = "gitbackup_test_bin.exe"
+	}
+
+	cmd := exec.Command("go", "build", "-o", binaryFilename)
 	stdoutStderr, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("Error building test binary: %v - %v", err, string(stdoutStderr))
 	}
 	defer func() {
-		err := os.Remove("gitbackup_test_bin")
+		err := os.Remove(binaryFilename)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -27,7 +33,8 @@ func TestCliUsage(t *testing.T) {
 	goldenFilepath := path.Join("testdata", t.Name()+".golden")
 	goldenFilepathNew := goldenFilepath + ".expected"
 
-	cmd = exec.Command("./gitbackup_test_bin", "-h")
+	cmd = exec.Command("./"+binaryFilename, "-h")
+	t.Log(cmd.String())
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	err = cmd.Run()

--- a/testdata/TestCliUsage.golden
+++ b/testdata/TestCliUsage.golden
@@ -1,0 +1,33 @@
+Usage of ./gitbackup_test_bin:
+  -backupdir string
+    	Backup directory
+  -bare
+    	Clone bare repositories
+  -githost.url string
+    	DNS of the custom Git host
+  -github.createUserMigration
+    	Download user data
+  -github.createUserMigrationRetry
+    	Retry creating the GitHub user migration if we get an error (default true)
+  -github.createUserMigrationRetryMax int
+    	Number of retries to attempt for creating GitHub user migration (default 5)
+  -github.listUserMigrations
+    	List available user migrations
+  -github.namespaceWhitelist string
+    	Organizations/Users from where we should clone (separate each value by a comma: 'user1,org2')
+  -github.repoType string
+    	Repo types to backup (all, owner, member, starred) (default "all")
+  -github.waitForUserMigration
+    	Wait for migration to complete (default true)
+  -gitlab.projectMembershipType string
+    	Project type to clone (all, owner, member, starred) (default "all")
+  -gitlab.projectVisibility string
+    	Visibility level of Projects to clone (internal, public, private) (default "internal")
+  -ignore-fork
+    	Ignore repositories which are forks
+  -ignore-private
+    	Ignore private repositories/projects
+  -service string
+    	Git Hosted Service Name (github/gitlab/bitbucket)
+  -use-https-clone
+    	Use HTTPS for cloning instead of SSH

--- a/testdata/TestCliUsage.golden.windows
+++ b/testdata/TestCliUsage.golden.windows
@@ -31,4 +31,3 @@ Usage of ./gitbackup_test_bin.exe:
     	Git Hosted Service Name (github/gitlab/bitbucket)
   -use-https-clone
     	Use HTTPS for cloning instead of SSH
-

--- a/testdata/TestCliUsage.golden.windows
+++ b/testdata/TestCliUsage.golden.windows
@@ -1,0 +1,33 @@
+Usage of ./gitbackup_test_bin.exe:
+  -backupdir string
+    	Backup directory
+  -bare
+    	Clone bare repositories
+  -githost.url string
+    	DNS of the custom Git host
+  -github.createUserMigration
+    	Download user data
+  -github.createUserMigrationRetry
+    	Retry creating the GitHub user migration if we get an error (default true)
+  -github.createUserMigrationRetryMax int
+    	Number of retries to attempt for creating GitHub user migration (default 5)
+  -github.listUserMigrations
+    	List available user migrations
+  -github.namespaceWhitelist string
+    	Organizations/Users from where we should clone (separate each value by a comma: 'user1,org2')
+  -github.repoType string
+    	Repo types to backup (all, owner, member, starred) (default "all")
+  -github.waitForUserMigration
+    	Wait for migration to complete (default true)
+  -gitlab.projectMembershipType string
+    	Project type to clone (all, owner, member, starred) (default "all")
+  -gitlab.projectVisibility string
+    	Visibility level of Projects to clone (internal, public, private) (default "internal")
+  -ignore-fork
+    	Ignore repositories which are forks
+  -ignore-private
+    	Ignore private repositories/projects
+  -service string
+    	Git Hosted Service Name (github/gitlab/bitbucket)
+  -use-https-clone
+    	Use HTTPS for cloning instead of SSH

--- a/testdata/TestCliUsage.golden.windows
+++ b/testdata/TestCliUsage.golden.windows
@@ -31,3 +31,4 @@ Usage of ./gitbackup_test_bin.exe:
     	Git Hosted Service Name (github/gitlab/bitbucket)
   -use-https-clone
     	Use HTTPS for cloning instead of SSH
+


### PR DESCRIPTION
This PR adds a test for verifying the usage message that is displayed when `-h` is specified.

One reason I am adding this is to enable a refactor of the flag parsing logic that we have now.