### PR TITLE
forgejo custom host: Don't append /api path

### DIFF
--- a/git_repository_clone.go
+++ b/git_repository_clone.go
@@ -7,7 +7,7 @@ import (
 )
 
 // handleGitRepositoryClone clones or updates all repositories for the configured service
-func handleGitRepositoryClone(client interface{}, c *appConfig) error {
+func handleGitRepositoryClone(client any, c *appConfig) error {
 
 	// Used for waiting for all the goroutines to finish before exiting
 	var wg sync.WaitGroup


### PR DESCRIPTION
Don't append /api path for forgejo as the SDK takes care of it.

Fix for issue #193 